### PR TITLE
feat: core logic for user registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,16 @@
 # This is explicitly passed here for development purposes, it should match the
 # same as on `fixtures/synapse/homeserver.yaml` for CI.
 COMMUNE_REGISTRATION_SHARED_SECRET='m@;wYOUOh0f:CH5XA65sJB1^q01~DmIriOysRImot,OR_vzN&B'
+
+# Found in the Database after generating an admin user via `just gen_synapse_admin_user`
+# in the `access_tokens` table.
+COMMUNE_SYNAPSE_ADMIN_TOKEN='syt_YWRtaW4_PBgBsbKyGWAStLEglXZj_36o6mk'
 COMMUNE_SYNAPSE_HOST='http://0.0.0.0:8008'
+# Found in the homeserver.yaml file
+COMMUNE_SYNAPSE_SERVER_NAME='matrix.localhost'
 
 # Matrix Client
 MATRIX_HOST=http://localhost:8008
-MATRIX_ADMIN_TOKEN=secret
 
 # PostgreSQL
 POSTGRES_USER=synapse_user
@@ -17,6 +22,9 @@ POSTGRES_PASSWORD=secretpassword
 POSTGRES_DB=synapse
 # https://www.postgresql.org/docs/current/app-initdb.html
 POSTGRES_INITDB_ARGS='--no-locale --encoding=UTF8'
+
+# Rust Logging
+RUST_LOG=info
 
 # Synapse
 SYNAPSE_SERVER_NAME=matrix.localhost

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [workspace]
 members = [
+    "crates/core",
     "crates/matrix",
     "crates/test"
 ]
 resolver = "1"
 
 [workspace.dependencies]
+anyhow = "1.0.75"
+reqwest = "0.11.22"
 serde = "1.0.192"
 url = { version = "2.4.1", features = ["serde"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "core"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "commune"
+path = "src/lib.rs"
+
+[dependencies]
+validator = { version = "0.16", features = ["derive"] }
+
+# Workspace
+anyhow = { workspace = true }
+
+# Local Dependencies
+matrix = { path = "../matrix" }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,8 @@ pub mod util;
 
 use std::fmt::Debug;
 
+use anyhow::Result;
+
 use matrix::admin::Client as MatrixAdminClient;
 
 use self::user::service::UserService;
@@ -20,15 +22,14 @@ pub struct Commune {
 }
 
 impl Commune {
-    pub fn new<C: Into<CommuneConfig>>(config: C) -> Self {
+    pub fn new<C: Into<CommuneConfig>>(config: C) -> Result<Self> {
         let config: CommuneConfig = config.into();
-        let mut admin =
-            MatrixAdminClient::new(config.synapse_host, config.synapse_server_name).unwrap();
+        let mut admin = MatrixAdminClient::new(config.synapse_host, config.synapse_server_name)?;
 
-        admin.set_token(config.synapse_admin_token).unwrap();
+        admin.set_token(config.synapse_admin_token)?;
 
-        Self {
+        Ok(Self {
             user: UserService::new(admin),
-        }
+        })
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,0 +1,34 @@
+pub mod user;
+pub mod util;
+
+use std::fmt::Debug;
+
+use matrix::admin::Client as MatrixAdminClient;
+
+use self::user::service::UserService;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CommuneConfig {
+    pub synapse_host: String,
+    pub synapse_admin_token: String,
+    pub synapse_server_name: String,
+    pub synapse_registration_shared_secret: String,
+}
+
+pub struct Commune {
+    pub user: UserService,
+}
+
+impl Commune {
+    pub fn new<C: Into<CommuneConfig>>(config: C) -> Self {
+        let config: CommuneConfig = config.into();
+        let mut admin =
+            MatrixAdminClient::new(config.synapse_host, config.synapse_server_name).unwrap();
+
+        admin.set_token(config.synapse_admin_token).unwrap();
+
+        Self {
+            user: UserService::new(admin),
+        }
+    }
+}

--- a/crates/core/src/user/mod.rs
+++ b/crates/core/src/user/mod.rs
@@ -1,0 +1,2 @@
+pub mod model;
+pub mod service;

--- a/crates/core/src/user/model.rs
+++ b/crates/core/src/user/model.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone)]
+pub struct User {
+    pub username: String,
+    pub email: String,
+    pub session: String,
+    pub code: String,
+}

--- a/crates/core/src/user/service.rs
+++ b/crates/core/src/user/service.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use validator::Validate;
+
+use matrix::admin::resources::user::{ThreePid, User as MatrixUser, UserCreateDto};
+use matrix::admin::resources::user_id::UserId;
+use matrix::admin::Client as MatrixAdminClient;
+
+use crate::util::time::timestamp;
+
+use super::model::User;
+
+#[derive(Debug, Validate)]
+pub struct CreateAccountDto {
+    #[validate(length(min = 8, max = 12))]
+    pub username: String,
+    #[validate(length(min = 8, max = 12))]
+    pub password: String,
+    #[validate(email)]
+    pub email: String,
+    pub session: String,
+    pub code: String,
+}
+
+pub struct UserService {
+    admin: MatrixAdminClient,
+}
+
+impl UserService {
+    pub fn new(admin: MatrixAdminClient) -> Self {
+        Self { admin }
+    }
+
+    pub async fn register(&self, dto: CreateAccountDto) -> Result<User> {
+        dto.validate()?;
+
+        let user_id = UserId::new(dto.username.clone(), self.admin.server_name().to_string());
+        let matrix_user = MatrixUser::create(
+            &self.admin,
+            user_id,
+            UserCreateDto {
+                displayname: Some(dto.username),
+                password: dto.password,
+                logout_devices: false,
+                avatar_url: None,
+                threepids: vec![ThreePid {
+                    medium: "email".to_string(),
+                    address: dto.email,
+                    added_at: timestamp().unwrap(),
+                    validated_at: timestamp().unwrap(),
+                }],
+                external_ids: Vec::default(),
+                admin: false,
+                deactivated: false,
+                user_type: None,
+                locked: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        Ok(User {
+            username: matrix_user.displayname.unwrap(),
+            email: matrix_user.threepids.first().unwrap().address.clone(),
+            session: dto.session,
+            code: dto.code,
+        })
+    }
+}

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod time;

--- a/crates/core/src/util/time.rs
+++ b/crates/core/src/util/time.rs
@@ -1,0 +1,8 @@
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
+
+pub fn timestamp() -> Result<u64, SystemTimeError> {
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH)?;
+
+    Ok(since_the_epoch.as_secs())
+}

--- a/crates/matrix/Cargo.toml
+++ b/crates/matrix/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.75"
 async-trait = "0.1.74"
 hex = "0.4.3"
 hmac = "0.12.1"
 matrix-sdk = { git = "https://github.com/matrix-org/matrix-rust-sdk.git", rev = "e43a25a" }
-reqwest = { version = "0.11.22", features = ["json"] }
 serde_path_to_error = "0.1.14"
 serde_qs = "0.12.0"
 sha1 = "0.10.6"
 
 # Workspace Dependencies
+anyhow = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }

--- a/crates/matrix/src/admin/client.rs
+++ b/crates/matrix/src/admin/client.rs
@@ -11,17 +11,25 @@ pub struct Client {
     client: HttpClient,
     base_url: Url,
     token: Option<String>,
+    server_name: String,
 }
 
 impl Client {
-    pub fn new<S: AsRef<str>>(url: S) -> Result<Self> {
+    pub fn new<S: AsRef<str>>(url: S, server_name: S) -> Result<Self> {
         let url = Url::parse(url.as_ref())?;
+        let server_name = server_name.as_ref().to_string();
 
         Ok(Self {
             client: HttpClient::new(),
             base_url: url,
             token: None,
+            server_name,
         })
+    }
+
+    #[inline]
+    pub fn server_name(&self) -> &str {
+        &self.server_name
     }
 
     /// Sets the token to be used for authentication with the server.

--- a/crates/matrix/src/admin/resources/mod.rs
+++ b/crates/matrix/src/admin/resources/mod.rs
@@ -1,1 +1,3 @@
 pub mod token;
+pub mod user;
+pub mod user_id;

--- a/crates/matrix/src/admin/resources/user.rs
+++ b/crates/matrix/src/admin/resources/user.rs
@@ -1,0 +1,130 @@
+//! [User Admin API](https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#user-admin-api)
+//!
+//! To use it, you will need to authenticate by providing an `access_token`
+//! for a server admin: see Admin API.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::admin::Client;
+
+use super::user_id::UserId;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExternalId {
+    pub auth_provider: String,
+    pub external_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ThreePid {
+    pub medium: String,
+    pub address: String,
+    pub added_at: u64,
+    pub validated_at: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct User {
+    /// User name postfixed with Matrix instance Host
+    /// E.g. `@user:example.com`
+    pub name: String,
+    pub displayname: Option<String>,
+    pub threepids: Vec<ThreePid>,
+    pub avatar_url: Option<Url>,
+    pub is_guest: bool,
+    pub admin: bool,
+    pub deactivated: bool,
+    pub erased: bool,
+    pub shadow_banned: bool,
+    pub creation_ts: u64,
+    pub appservice_id: Option<String>,
+    pub consent_server_notice_sent: Option<u64>,
+    pub consent_version: Option<String>,
+    pub consent_ts: Option<u64>,
+    pub external_ids: Vec<ExternalId>,
+    pub user_type: Option<String>,
+    pub locked: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserCreateDto {
+    pub password: String,
+    pub logout_devices: bool,
+    pub displayname: Option<String>,
+    pub avatar_url: Option<Url>,
+    pub threepids: Vec<ThreePid>,
+    pub external_ids: Vec<ExternalId>,
+    pub admin: bool,
+    pub deactivated: bool,
+    pub user_type: Option<String>,
+    pub locked: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListUsersParams {
+    user_id: Option<String>,
+    name: Option<String>,
+    guests: Option<bool>,
+    admins: Option<bool>,
+    deactivated: Option<bool>,
+    limit: Option<u64>,
+    from: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserUpdateDto {
+    pub password: String,
+    pub logout_devices: bool,
+    pub displayname: Option<String>,
+    pub avatar_url: Option<Url>,
+    pub threepids: Vec<ThreePid>,
+    pub external_ids: Vec<ExternalId>,
+    pub admin: bool,
+    pub deactivated: bool,
+    pub user_type: Option<String>,
+    pub locked: bool,
+}
+
+impl User {
+    /// Allows an administrator to create a user account
+    ///
+    /// Refer: https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#create-or-modify-account
+    pub async fn create(client: &Client, user_id: UserId, dto: UserCreateDto) -> Result<Self> {
+        let resp = client
+            .put_json(
+                format!("/_synapse/admin/v2/users/{user_id}", user_id = user_id),
+                &dto,
+            )
+            .await?;
+
+        Ok(resp.json().await?)
+    }
+
+    /// Returns all local user accounts. By default, the response is ordered by
+    /// ascending user ID.
+    ///
+    /// Refer: https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#list-accounts
+    pub async fn list(client: &Client, params: ListUsersParams) -> Result<Self> {
+        let resp = client
+            .get_query("/_synapse/admin/v2/users", &params)
+            .await?;
+
+        Ok(resp.json().await?)
+    }
+
+    /// Allows an administrator to modify a user account
+    ///
+    /// Refer: https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#create-or-modify-account
+    pub async fn update(client: &Client, user_id: UserId, dto: UserUpdateDto) -> Result<Self> {
+        let resp = client
+            .put_json(
+                format!("/_synapse/admin/v2/users/{user_id}", user_id = user_id),
+                &dto,
+            )
+            .await?;
+
+        Ok(resp.json().await?)
+    }
+}

--- a/crates/matrix/src/admin/resources/user_id.rs
+++ b/crates/matrix/src/admin/resources/user_id.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, fmt::Display};
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// @user:server.com
 /// ```
 ///

--- a/crates/matrix/src/admin/resources/user_id.rs
+++ b/crates/matrix/src/admin/resources/user_id.rs
@@ -1,0 +1,36 @@
+use std::{borrow::Cow, fmt::Display};
+
+/// A Matrix user ID.
+///
+/// # Example
+///
+/// ```
+/// @user:server.com
+/// ```
+///
+/// The `server` value corresponds to the Synapse Server Name and can be
+/// found on homeserver.yaml.
+///
+/// # Devnotes
+///
+/// Perhaps using Ruma's `UserId` would be better?
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UserId(Cow<'static, str>);
+
+impl UserId {
+    pub fn new<S: AsRef<str>>(name: S, server_name: S) -> Self {
+        let user_id = format!(
+            "@{name}:{server_name}",
+            name = name.as_ref(),
+            server_name = server_name.as_ref()
+        );
+
+        Self(user_id.into())
+    }
+}
+
+impl Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/crates/test/src/environment.rs
+++ b/crates/test/src/environment.rs
@@ -4,6 +4,7 @@ use matrix::admin::Client;
 
 const COMMUNE_REGISTRATION_SHARED_SECRET: &str = "COMMUNE_REGISTRATION_SHARED_SECRET";
 const COMMUNE_SYNAPSE_HOST: &str = "COMMUNE_SYNAPSE_HOST";
+const COMMUNE_SYNAPSE_SERVER_NAME: &str = "COMMUNE_SYNAPSE_SERVER_NAME";
 
 pub struct Environment {
     pub client: Client,
@@ -15,7 +16,8 @@ impl Environment {
         dotenv::dotenv().ok();
 
         let synapse_host = Self::env_var(COMMUNE_SYNAPSE_HOST);
-        let client = Client::new(synapse_host).unwrap();
+        let synapse_server_name = Self::env_var(COMMUNE_SYNAPSE_SERVER_NAME);
+        let client = Client::new(synapse_host, synapse_server_name).unwrap();
         let registration_shared_secret = Self::env_var(COMMUNE_REGISTRATION_SHARED_SECRET);
 
         Self {

--- a/crates/test/src/matrix/shared_token_registration.rs
+++ b/crates/test/src/matrix/shared_token_registration.rs
@@ -14,7 +14,7 @@ async fn creates_user_using_shared_secret() {
     let mac = SharedSecretRegistration::generate_mac(
         env.registration_shared_secret,
         nonce.clone(),
-        "steve".into(),
+        "steve_campbell".into(),
         "verysecure".into(),
         true,
         None,
@@ -24,8 +24,8 @@ async fn creates_user_using_shared_secret() {
         &env.client,
         SharedSecretRegistrationDto {
             nonce,
-            username: "steve".into(),
-            displayname: Some("steve".into()),
+            username: "steve_campbell".into(),
+            displayname: Some("steve_campbell".into()),
             password: "verysecure".into(),
             admin: true,
             mac,


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Provides `core` crate for application logic. As of now it includes a very naive implementation on https://github.com/commune-os/commune-server/blob/main/app/accounts.go#L18.