### PR TITLE
feat: token aware routes with middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ reqwest = "0.11.22"
 serde = "1.0.192"
 serde_json = "1.0.108"
 tokio = "1.34.0"
-tower = "0.4.13"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 uuid = { version = "1.6.1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = "0.11.22"
 serde = "1.0.192"
 serde_json = "1.0.108"
 tokio = "1.34.0"
+tower = "0.4.13"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 uuid = { version = "1.6.1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "1"
 
 [workspace.dependencies]
 anyhow = "1.0.75"
-axum = "0.6.19"
+axum = { version = "0.7.4", features = ["tokio"] }
 dotenv = "0.15.0"
 http = "0.2.11"
 reqwest = "0.11.22"

--- a/crates/core/src/account/service.rs
+++ b/crates/core/src/account/service.rs
@@ -249,7 +249,7 @@ impl AccountService {
         Ok(credentials.access_token)
     }
 
-    pub async fn whoami(&self, access_token: Secret) -> Result<Account> {
+    pub async fn whoami(&self, access_token: &Secret) -> Result<Account> {
         let session = Session::get(&self.admin, access_token.to_string())
             .await
             .map_err(|err| {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0.108"
 axum = { workspace = true, features = ["tokio"] }
 anyhow = { workspace = true }
 dotenv = { workspace = true }
+http = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tower = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true }
 dotenv = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true, features= ["serde"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -22,7 +22,6 @@ dotenv = { workspace = true }
 http = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
-tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true, features= ["serde"] }

--- a/crates/server/src/bin/main.rs
+++ b/crates/server/src/bin/main.rs
@@ -1,7 +1,8 @@
-use std::net::{SocketAddr, TcpListener};
+use std::net::SocketAddr;
 
 use anyhow::Result;
 use dotenv::dotenv;
+use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -12,7 +13,7 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    let tcp = TcpListener::bind(addr)?;
+    let tcp = TcpListener::bind(addr).await?;
 
     tracing::info!("Listening on {}", addr);
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,6 +1,5 @@
-use std::net::TcpListener;
-
 use anyhow::Result;
+use tokio::net::TcpListener;
 
 pub mod config;
 pub mod router;
@@ -10,15 +9,15 @@ use crate::config::ServerConfig;
 use crate::router::make_router;
 use crate::services::Services;
 
-pub async fn serve(tcp: TcpListener) -> Result<()> {
+pub async fn serve(listener: TcpListener) -> Result<()> {
     let config = ServerConfig::from_env();
     let services = Services::shared(config).await?;
-    let router = make_router();
-    let router = router.with_state(services);
+    let router = make_router(services);
 
-    axum::Server::from_tcp(tcp)?
-        .serve(router.into_make_service())
-        .await?;
+    if let Err(err) = axum::serve(listener, router.into_make_service()).await {
+        tracing::error!(%err, "Failed to initialize the server");
+        panic!("An error ocurred running the server!");
+    }
 
     Ok(())
 }

--- a/crates/server/src/router/api/mod.rs
+++ b/crates/server/src/router/api/mod.rs
@@ -34,6 +34,22 @@ impl ApiError {
             status,
         }
     }
+
+    pub fn unauthorized() -> Self {
+        Self::new(
+            "You must be authenticated to access this request".to_string(),
+            "UNAUTHORIZED",
+            StatusCode::UNAUTHORIZED,
+        )
+    }
+
+    pub fn internal_server_error() -> Self {
+        Self::new(
+            "Internal server error".to_string(),
+            "INTERNAL_SERVER_ERROR",
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    }
 }
 
 impl From<commune::error::Error> for ApiError {

--- a/crates/server/src/router/api/mod.rs
+++ b/crates/server/src/router/api/mod.rs
@@ -4,6 +4,7 @@ use axum::response::IntoResponse;
 use axum::Json;
 use axum::Router;
 use http::StatusCode;
+use serde::Deserialize;
 use serde::Serialize;
 
 use commune::error::HttpStatusCode;
@@ -16,16 +17,16 @@ impl Api {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ApiError {
-    message: String,
-    code: &'static str,
+    pub message: String,
+    pub code: String,
     #[serde(skip)]
-    status: StatusCode,
+    pub status: StatusCode,
 }
 
 impl ApiError {
-    pub fn new(message: String, code: &'static str, status: StatusCode) -> Self {
+    pub fn new(message: String, code: String, status: StatusCode) -> Self {
         Self {
             message,
             code,
@@ -35,8 +36,8 @@ impl ApiError {
 
     pub fn unauthorized() -> Self {
         Self::new(
-            "You must be authenticated to access this request".to_string(),
-            "UNAUTHORIZED",
+            "You must be authenticated to access this resource".to_string(),
+            "UNAUTHORIZED".to_string(),
             StatusCode::UNAUTHORIZED,
         )
     }
@@ -44,7 +45,7 @@ impl ApiError {
     pub fn internal_server_error() -> Self {
         Self::new(
             "Internal server error".to_string(),
-            "INTERNAL_SERVER_ERROR",
+            "INTERNAL_SERVER_ERROR".to_string(),
             StatusCode::INTERNAL_SERVER_ERROR,
         )
     }
@@ -54,7 +55,7 @@ impl From<commune::error::Error> for ApiError {
     fn from(err: commune::error::Error) -> Self {
         Self {
             message: err.to_string(),
-            code: err.error_code(),
+            code: err.error_code().to_string(),
             status: err.status_code(),
         }
     }
@@ -71,7 +72,7 @@ impl From<anyhow::Error> for ApiError {
     fn from(err: anyhow::Error) -> Self {
         Self {
             message: err.to_string(),
-            code: "UNKNOWN_ERROR",
+            code: "UNKNOWN_ERROR".to_string(),
             status: StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -79,11 +80,14 @@ impl From<anyhow::Error> for ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
-        let status = self.status.as_u16();
-        let mut response = Json(self).into_response();
+        if let Ok(status) = axum::http::StatusCode::from_u16(self.status.as_u16()) {
+            let mut response = Json(self).into_response();
 
-        *response.status_mut() =
-            axum::http::StatusCode::from_u16(status).expect("Invalid status code");
-        response
+            *response.status_mut() = status;
+            return response;
+        }
+
+        tracing::error!(status=%self.status, "Failed to convert status code to http::StatusCode");
+        ApiError::internal_server_error().into_response()
     }
 }

--- a/crates/server/src/router/api/v1/account/email.rs
+++ b/crates/server/src/router/api/v1/account/email.rs
@@ -1,7 +1,7 @@
-use axum::extract::{Path, State};
+use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -10,7 +10,7 @@ use crate::services::SharedServices;
 
 #[instrument(skip(services))]
 pub async fn handler(
-    State(services): State<SharedServices>,
+    Extension(services): Extension<SharedServices>,
     Path(email): Path<String>,
 ) -> Response {
     match services.commune.account.is_email_available(&email).await {

--- a/crates/server/src/router/api/v1/account/login.rs
+++ b/crates/server/src/router/api/v1/account/login.rs
@@ -1,7 +1,6 @@
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{Extension, Json};
 use commune::Error;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -15,7 +14,7 @@ use super::root::{AccountMatrixCredentials, AccountSpace};
 
 #[instrument(skip(services, payload))]
 pub async fn handler(
-    State(services): State<SharedServices>,
+    Extension(services): Extension<SharedServices>,
     Json(payload): Json<AccountLoginPayload>,
 ) -> Response {
     let login_credentials = LoginCredentials::from(payload);
@@ -28,12 +27,7 @@ pub async fn handler(
         .into_response();
     };
 
-    match services
-        .commune
-        .account
-        .whoami(tokens.access_token.clone())
-        .await
-    {
+    match services.commune.account.whoami(&tokens.access_token).await {
         Ok(account) => {
             let mut response = Json(AccountLoginResponse {
                 access_token: tokens.access_token.to_string(),

--- a/crates/server/src/router/api/v1/account/mod.rs
+++ b/crates/server/src/router/api/v1/account/mod.rs
@@ -9,12 +9,11 @@ use axum::routing::{get, post};
 use axum::{middleware, Router};
 
 use crate::router::middleware::auth;
-use crate::services::SharedServices;
 
 pub struct Account;
 
 impl Account {
-    pub fn routes() -> Router<SharedServices> {
+    pub fn routes() -> Router {
         Router::new()
             .route("/session", get(session::handler))
             .route_layer(middleware::from_fn(auth))

--- a/crates/server/src/router/api/v1/account/root.rs
+++ b/crates/server/src/router/api/v1/account/root.rs
@@ -1,7 +1,6 @@
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{Extension, Json};
 
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -16,7 +15,7 @@ use crate::services::SharedServices;
 
 #[instrument(skip(services, payload))]
 pub async fn handler(
-    State(services): State<SharedServices>,
+    Extension(services): Extension<SharedServices>,
     Json(payload): Json<AccountRegisterPayload>,
 ) -> Response {
     let dto = CreateAccountDto::from(payload);

--- a/crates/server/src/router/api/v1/account/session.rs
+++ b/crates/server/src/router/api/v1/account/session.rs
@@ -1,0 +1,28 @@
+use axum::extract::State;
+
+use axum::response::{IntoResponse, Response};
+use axum::Extension;
+use commune::account::model::Account;
+
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+use crate::services::SharedServices;
+
+use super::root::{AccountMatrixCredentials, AccountSpace};
+
+#[instrument(skip(_services))]
+pub async fn handler(
+    Extension(whoami): Extension<Account>,
+    State(_services): State<SharedServices>,
+) -> Response {
+    println!("whoami: {:?}", whoami);
+    "Hello World!".into_response()
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AccountSessionResponse {
+    pub credentials: AccountMatrixCredentials,
+    pub rooms: Vec<String>,
+    pub spaces: Vec<AccountSpace>,
+}

--- a/crates/server/src/router/api/v1/account/verify_code.rs
+++ b/crates/server/src/router/api/v1/account/verify_code.rs
@@ -1,7 +1,6 @@
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{Extension, Json};
 use commune::account::error::AccountErrorCode;
 use commune::Error;
 use serde::{Deserialize, Serialize};
@@ -15,7 +14,7 @@ use crate::services::SharedServices;
 
 #[instrument(skip(services, payload))]
 pub async fn handler(
-    State(services): State<SharedServices>,
+    Extension(services): Extension<SharedServices>,
     Json(payload): Json<AccountVerifyCodePayload>,
 ) -> Response {
     let dto = SendCodeDto::from(payload);

--- a/crates/server/src/router/api/v1/account/verify_code_email.rs
+++ b/crates/server/src/router/api/v1/account/verify_code_email.rs
@@ -1,7 +1,6 @@
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum::{Extension, Json};
 use commune::account::error::AccountErrorCode;
 use commune::util::secret::Secret;
 use commune::Error;
@@ -16,7 +15,7 @@ use crate::services::SharedServices;
 
 #[instrument(skip(services, payload))]
 pub async fn handler(
-    State(services): State<SharedServices>,
+    Extension(services): Extension<SharedServices>,
     Json(payload): Json<AccountVerifyCodeEmailPayload>,
 ) -> Response {
     let dto = VerifyCodeDto::from(payload);

--- a/crates/server/src/router/api/v1/mod.rs
+++ b/crates/server/src/router/api/v1/mod.rs
@@ -2,12 +2,10 @@ pub mod account;
 
 use axum::Router;
 
-use crate::services::SharedServices;
-
 pub struct V1;
 
 impl V1 {
-    pub fn routes() -> Router<SharedServices> {
+    pub fn routes() -> Router {
         Router::new().nest("/account", account::Account::routes())
     }
 }

--- a/crates/server/src/router/middleware/auth.rs
+++ b/crates/server/src/router/middleware/auth.rs
@@ -1,0 +1,39 @@
+use axum::http::{header::AUTHORIZATION, Request};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use commune::util::secret::Secret;
+
+use crate::router::api::ApiError;
+use crate::services::SharedServices;
+
+pub async fn auth<T>(mut request: Request<T>, next: Next<T>) -> Result<Response, ApiError> {
+    let access_token = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .ok_or(ApiError::unauthorized())?
+        .to_owned();
+
+    let services = request
+        .extensions()
+        .get::<SharedServices>()
+        .ok_or_else(|| {
+            tracing::error!("SharedServices not found in request extensions");
+            ApiError::internal_server_error()
+        })?;
+
+    let user = services
+        .commune
+        .account
+        .whoami(Secret::new(access_token))
+        .await
+        .map_err(|err| {
+            tracing::error!("Failed to validate token: {}", err);
+            ApiError::internal_server_error()
+        })?;
+
+    request.extensions_mut().insert(user);
+    Ok(next.run(request).await)
+}

--- a/crates/server/src/router/middleware/mod.rs
+++ b/crates/server/src/router/middleware/mod.rs
@@ -1,0 +1,3 @@
+mod auth;
+
+pub use auth::auth;

--- a/crates/server/src/router/middleware/mod.rs
+++ b/crates/server/src/router/middleware/mod.rs
@@ -1,3 +1,3 @@
 mod auth;
 
-pub use auth::auth;
+pub use auth::{auth, AccessToken};

--- a/crates/server/src/router/mod.rs
+++ b/crates/server/src/router/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod middleware;
 
 use axum::Router;
 

--- a/crates/server/src/router/mod.rs
+++ b/crates/server/src/router/mod.rs
@@ -1,10 +1,13 @@
 pub mod api;
 pub mod middleware;
 
+use axum::Extension;
 use axum::Router;
 
 use crate::services::SharedServices;
 
-pub fn make_router() -> Router<SharedServices> {
-    Router::new().nest("/api", api::Api::routes())
+pub fn make_router(service: SharedServices) -> Router {
+    Router::new()
+        .merge(api::Api::routes())
+        .layer(Extension(service))
 }

--- a/crates/test/src/server/api/v1/account/mod.rs
+++ b/crates/test/src/server/api/v1/account/mod.rs
@@ -1,2 +1,3 @@
 mod login;
 mod root;
+mod session;

--- a/crates/test/src/server/api/v1/account/session.rs
+++ b/crates/test/src/server/api/v1/account/session.rs
@@ -1,0 +1,148 @@
+use commune_server::router::api::v1::account::root::AccountRegisterPayload;
+use commune_server::router::api::v1::account::session::AccountSessionResponse;
+use commune_server::router::api::ApiError;
+use fake::faker::internet::en::{FreeEmail, Password};
+use fake::Fake;
+use reqwest::StatusCode;
+use scraper::Selector;
+use uuid::Uuid;
+
+use commune::util::secret::Secret;
+use commune_server::router::api::v1::account::login::{AccountLoginPayload, AccountLoginResponse};
+use commune_server::router::api::v1::account::verify_code::{
+    AccountVerifyCodePayload, VerifyCodeResponse,
+};
+use commune_server::router::api::v1::account::verify_code_email::{
+    AccountVerifyCodeEmailPayload, VerifyCodeEmailResponse,
+};
+
+use crate::tools::http::HttpClient;
+use crate::tools::maildev::MailDevClient;
+
+#[tokio::test]
+async fn retrieves_session_user_from_token() {
+    let http_client = HttpClient::new().await;
+    let session = Uuid::new_v4();
+    let email: String = FreeEmail().fake();
+    let verify_code_pld = AccountVerifyCodePayload {
+        email: email.clone(),
+        session,
+    };
+    let verify_code_res = http_client
+        .post("/api/v1/account/verify/code")
+        .json(&verify_code_pld)
+        .send()
+        .await;
+    let verify_code = verify_code_res.json::<VerifyCodeResponse>().await;
+
+    assert!(verify_code.sent, "should return true for sent");
+
+    let maildev = MailDevClient::new();
+    let mail = maildev.latest().await.unwrap().unwrap();
+    let html = mail.html();
+    let code_sel = Selector::parse("#code").unwrap();
+    let mut code_el = html.select(&code_sel);
+    let code = code_el.next().unwrap().inner_html();
+    let verify_code_email_pld = AccountVerifyCodeEmailPayload {
+        email: email.clone(),
+        code: Secret::new(code.clone()),
+        session,
+    };
+
+    let verify_code_res = http_client
+        .post("/api/v1/account/verify/code/email")
+        .json(&verify_code_email_pld)
+        .send()
+        .await;
+    let verify_code_email = verify_code_res.json::<VerifyCodeEmailResponse>().await;
+
+    assert!(verify_code_email.valid, "should return true for valid");
+
+    let username: String = (10..12).fake();
+    let username = username.to_ascii_lowercase();
+    let password: String = Password(14..20).fake();
+    let request_payload = AccountRegisterPayload {
+        username: username.clone(),
+        password: password.clone(),
+        email: email.clone(),
+        code,
+        session,
+    };
+    let response = http_client
+        .post("/api/v1/account")
+        .json(&request_payload)
+        .send()
+        .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "should return 201 for successful registration"
+    );
+
+    let response = http_client
+        .post("/api/v1/account/login")
+        .json(&AccountLoginPayload {
+            username: username.clone(),
+            password,
+        })
+        .send()
+        .await;
+    let response_status = response.status();
+    let response_payload = response.json::<AccountLoginResponse>().await;
+
+    assert_eq!(
+        response_status,
+        StatusCode::OK,
+        "should return 200 for successful login"
+    );
+    assert!(!response_payload.access_token.is_empty());
+
+    let session_res = http_client
+        .get("/api/v1/account/session")
+        .token(response_payload.access_token)
+        .send()
+        .await;
+    let session_res_status = session_res.status();
+    let session_res_payload = session_res.json::<AccountSessionResponse>().await;
+
+    assert_eq!(
+        session_res_status,
+        StatusCode::OK,
+        "should return 200 for successful session"
+    );
+    assert!(session_res_payload
+        .credentials
+        .username
+        .starts_with(&format!("@{}", username)));
+    assert_eq!(
+        session_res_payload.credentials.email, email,
+        "should return email"
+    );
+    assert!(
+        session_res_payload.credentials.verified,
+        "should return verified"
+    );
+    assert!(
+        !session_res_payload.credentials.admin,
+        "should return admin"
+    );
+}
+
+#[tokio::test]
+async fn kicks_users_with_no_token_specified() {
+    let http_client = HttpClient::new().await;
+    let session_res = http_client.get("/api/v1/account/session").send().await;
+    let session_res_status = session_res.status();
+    let session_res_payload = session_res.json::<ApiError>().await;
+
+    assert_eq!(session_res_status, StatusCode::UNAUTHORIZED.as_u16(),);
+    assert_eq!(
+        session_res_payload.code, "UNAUTHORIZED",
+        "should return UNAUTHORIZED"
+    );
+    assert_eq!(
+        session_res_payload.message,
+        "You must be authenticated to access this resource",
+    );
+}

--- a/crates/test/src/tools/http.rs
+++ b/crates/test/src/tools/http.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 
 use dotenv::dotenv;
 use reqwest::{Client, StatusCode};
+use tokio::net::TcpListener;
 
 use commune_server::serve;
 
@@ -14,9 +15,7 @@ impl HttpClient {
     pub(crate) async fn new() -> Self {
         dotenv().ok();
 
-        let tcp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        tcp.set_nonblocking(true)
-            .expect("Failed to set non-blocking mode");
+        let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = tcp.local_addr().unwrap();
 
         tokio::spawn(async move {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.75.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.75.0"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Adds support for Bearer tokens in server by implementing a middleware that fetches the
account using the token specified in the HTTP headers of the request as:

```
Authorization: Bearer <TOKEN>
```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
