### PR TITLE
feat: allow creation of `space.board.post` events (WIP)

### DIFF
--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -16,3 +16,12 @@ pub mod admin;
 /// Different to the Matrix SDK, no user state is kept in the Client instance,
 /// this is equivalent to making cURL requests to the Matrix server.
 pub mod client;
+
+/// Implementation of our custom space events
+pub mod space;
+
+/// Implementation of database entities
+pub mod entities;
+
+/// Wrapper to open our database connection
+pub mod postgres;

--- a/crates/matrix/src/space/board.rs
+++ b/crates/matrix/src/space/board.rs
@@ -1,0 +1,66 @@
+use ruma::events::room::message::{FormattedBody, Relation};
+use ruma::events::Mentions;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum BoardType {
+    Post(BoardPostEventContent),
+    // not sure if this should be unit
+    _Custom(())
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "boardtype", rename = "space.board.post")]
+pub struct BoardPostEventContent {
+    /// The title of the post.
+    pub title: Option<String>,
+
+    /// The body of the post.
+    pub body: String,
+
+    /// Formatted form of the post `body`.
+    #[serde(flatten)]
+    pub formatted: Option<FormattedBody>,
+}
+
+#[derive(Clone, Debug, Serialize, EventContent)]
+#[ruma_event(type = "space.board", kind = MessageLike)]
+pub struct SpaceBoardContent {
+    #[serde(flatten)]
+    pub boardtype: BoardType,
+
+    /// Information about [related posts].
+    ///
+    /// [related posts]: https://spec.matrix.org/latest/client-server-api/#forming-relationships-between-events
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub relates_to: Option<Relation<SpaceBoardContentWithoutRelation>>,
+
+    /// The [mentions] of this event.
+    ///
+    /// This should always be set to avoid triggering the legacy mention push rules. It is
+    /// recommended to use [`Self::set_mentions()`] to set this field, that will take care of
+    /// populating the fields correctly if this is a replacement.
+    ///
+    /// [mentions]: https://spec.matrix.org/latest/client-server-api/#user-and-room-mentions
+    #[serde(rename = "m.mentions", skip_serializing_if = "Option::is_none")]
+    pub mentions: Option<Mentions>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SpaceBoardContentWithoutRelation {
+    #[serde(flatten)]
+    pub boardtype: BoardType,
+
+    /// The [mentions] of this event.
+    ///
+    /// This should always be set to avoid triggering the legacy mention push rules. It is
+    /// recommended to use [`Self::set_mentions()`] to set this field, that will take care of
+    /// populating the fields correctly if this is a replacement.
+    ///
+    /// [mentions]: https://spec.matrix.org/latest/client-server-api/#user-and-room-mentions
+    #[serde(rename = "m.mentions", skip_serializing_if = "Option::is_none")]
+    pub mentions: Option<Mentions>,
+}

--- a/crates/matrix/src/space/content_serde.rs
+++ b/crates/matrix/src/space/content_serde.rs
@@ -1,0 +1,47 @@
+use ruma::events::Mentions;
+use serde::{Deserialize, de};
+use ruma_common::serde::from_raw_json_value;
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::board::{BoardType, SpaceBoardContentWithoutRelation};
+
+impl<'de> Deserialize<'de> for SpaceBoardContentWithoutRelation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+
+        let MentionsDeHelper { mentions } = from_raw_json_value(&json)?;
+
+        Ok(Self { boardtype: from_raw_json_value(&json)?, mentions })
+    }
+}
+
+impl<'de> Deserialize<'de> for BoardType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let BoardTypeDeHelper { boardtype } = from_raw_json_value(&json)?;
+
+        Ok(match boardtype.as_ref() {
+            "space.board.post" => Self::Post(from_raw_json_value(&json)?),
+            _ => Self::_Custom(()),
+        })
+    }
+}
+
+/// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
+#[derive(Debug, Deserialize)]
+struct BoardTypeDeHelper {
+    /// The message type field
+    boardtype: String,
+}
+
+#[derive(Deserialize)]
+struct MentionsDeHelper {
+    #[serde(rename = "m.mentions")]
+    mentions: Option<Mentions>,
+}

--- a/crates/matrix/src/space/mod.rs
+++ b/crates/matrix/src/space/mod.rs
@@ -1,0 +1,5 @@
+pub mod board;
+pub mod content_serde;
+
+pub use ruma::events as ruma;
+pub use ruma_common::serde;


### PR DESCRIPTION
Provides the handler required to create a post.