### PR TITLE
chore(dev): use element-hq/synapse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ just backend
 
 **When you are ready**
 
-Teardown services using `just stop`. If you want to perform a complete cleanup
-use `just clear`.
+Teardown services using `just stop`.
+If you want to perform a complete cleanup use `just clear`.
 
 > **Warning** `just clear` will remove all containers and images.
 
@@ -122,3 +122,13 @@ For this purpose Redis is served as part of the development stack on Docker.
 
 The `redis/redis-stack` image contains both Redis Stack server and RedisInsight,
 you can use RedisInsight by pointing your browser to `localhost:8001`.
+
+#### Synapse
+
+There is an official [Synapse][1] image available at https://hub.docker.com/r/matrixdotorg/synapse
+or at `ghcr.io/matrix-org/synapse` which can be used with the `docker-compose`
+file available at [contrib/docker][2]. Further information on this including
+configuration options is available in the README on hub.docker.com.
+
+[1]: https://matrix-org.github.io/synapse/latest/setup/installation.html#docker-images-and-ansible-playbooks
+[2]: https://github.com/matrix-org/synapse/tree/develop/contrib/docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     restart: always
 
   synapse:
-    image: 'matrixdotorg/synapse:v1.96.1'
+    image: 'ghcr.io/element-hq/synapse:v1.100.0'
     ports:
       - '8008:8008'
       - '8448:8448'


### PR DESCRIPTION
Uses Synapse Docker Image from Element HQ, given that Matrix Synapse is now maintained
by team at Element HQ.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
