### PR TITLE
chore: make Docker environment easier to work with

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - '8001:8001'
     volumes:
       - redis-state:/data
-  
+
   synapse_database:
     image: 'postgres:16'
     ports:
@@ -27,6 +27,7 @@ services:
 
   synapse:
     image: 'ghcr.io/element-hq/synapse:v1.100.0'
+    user: '${UID:-1000}:${GID:-1000}'
     ports:
       - '8008:8008'
       - '8448:8448'


### PR DESCRIPTION
- Substitutes admin token directly in `.env`
- Sets ownership of `docker/synapse` to the user executing `docker` (this requires the directory to be present and owned by the user, otherwise docker will create it for us and set ownership to root)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
